### PR TITLE
GitInfo functionnality : Add ghApiCommitURL, and disable error reporting for remote get-json

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -12,6 +12,7 @@ params:
   editURL: "https://github.com/PrestaShop/docs/edit/"
   ghRepoURL: "https://github.com/PrestaShop/docs/"
   ghCommitURL: "https://github.com/PrestaShop/docs/commit/"
+  ghApiCommitURL: "https://api.github.com/repos/prestashop/docs/commits"
   howToContributeURL: "/8/contribute/documentation/how/"
   description: "Learn how to extend, modify and test PrestaShop, create modules, themes, and more."
   author: "PrestaShop"
@@ -64,3 +65,6 @@ ignoreFiles:
   - /LICENSE$
   - \.gitignore$
   - \.github$
+
+ignoreErrors:
+  - "error-remote-getjson"

--- a/src/config.yml
+++ b/src/config.yml
@@ -66,5 +66,8 @@ ignoreFiles:
   - \.gitignore$
   - \.github$
 
-ignoreErrors:
-  - "error-remote-getjson"
+security:
+  funcs:
+    getenv:
+      - ^HUGO_
+      - ^DEVDOCS_


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add the URL of github api commit url to get gitinfo on hugo.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
